### PR TITLE
fix: FBOT-682 fix overflowing scrollbar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1166,6 +1166,15 @@ const BaseTheme = (theme: Theme) => `
     body .feedbot-wrapper.collapsed .feedbot-header .feedbot-extra-html {
       display: none
     }
+
+    .wc-hscroll {
+      margin-bottom: 5px !important;
+    }
+
+    .wc-hscroll::-webkit-scrollbar{
+      width: 0;
+      height: 0;
+    }
   
     ${theme.enableScreenshotUpload && !isSafari() ? `
       .wc-upload-screenshot {


### PR DESCRIPTION
Fixed the scrollbar in carousels; it was caused by scrollbar overflowing from the hscroll wrapper when zooming out in chrome.